### PR TITLE
Fix Heroku deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,12 @@
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",
     "react-devtools": "^4.8.1",
+    "dotenv": "^8.2.0",
     "react-router-dom": "^5.2.0"
   },
   "devDependencies": {
     "chalk": "^4.1.0",
-    "dotenv": "^8.2.0",
+    
     "nodemon": "^2.0.4"
   }
 }


### PR DESCRIPTION
Move dotenv from  devDependencies to dependencies

Outside of our repo: Add Config vars (env vars) to Heroku: 
MONGO_URI (I think Heroku defaults process.env.NODE_ENV to "production", so MONGO_URI_DEV wasn't being used)
GOOGLE_CLIENT_ID
GOOGLE_SECRET_CLIENT

